### PR TITLE
feat(exchange): introduce `from`, `to` and `limit` parameters to fetchOHLCV

### DIFF
--- a/src/exchanges/bitget/bitget.exchange.ts
+++ b/src/exchanges/bitget/bitget.exchange.ts
@@ -471,20 +471,23 @@ export class BitgetExchange extends BaseExchange {
   };
 
   fetchOHLCV = async (opts: OHLCVOptions) => {
+    const limit = Math.min(opts.limit || 500, 1000);
     const interval = INTERVAL[opts.interval];
     const [, amount, unit] = opts.interval.split(/(\d+)/);
 
-    const from = dayjs()
-      .subtract(parseFloat(amount) * 200, unit as ManipulateType)
-      .valueOf();
+    const end = opts.to ? dayjs(opts.to) : dayjs();
+    const start =
+      !opts.limit && opts.from
+        ? dayjs(opts.from)
+        : end.subtract(parseFloat(amount) * limit, unit as ManipulateType);
 
     const { data } = await this.xhr.get(ENDPOINTS.KLINE, {
       params: {
         symbol: `${opts.symbol}_${this.apiProductType.toUpperCase()}`,
         granularity: interval,
-        startTime: from,
-        endTime: Date.now(),
-        limit: 500,
+        startTime: start.valueOf(),
+        endTime: end.valueOf(),
+        limit,
       },
     });
 

--- a/src/exchanges/bybit/bybit.exchange.ts
+++ b/src/exchanges/bybit/bybit.exchange.ts
@@ -470,21 +470,23 @@ export class BybitExchange extends BaseExchange {
   };
 
   fetchOHLCV = async (opts: OHLCVOptions) => {
+    const limit = Math.min(opts.limit || 500, 1000);
     const interval = INTERVAL[opts.interval];
     const [, amount, unit] = opts.interval.split(/(\d+)/);
 
-    const end = dayjs().valueOf();
-    const start = dayjs()
-      .subtract(parseFloat(amount) * 500, unit as ManipulateType)
-      .valueOf();
+    const end = opts.to ? dayjs(opts.to) : dayjs();
+    const start =
+      !opts.limit && opts.from
+        ? dayjs(opts.from)
+        : end.subtract(parseFloat(amount) * limit, unit as ManipulateType);
 
     const params = {
       category: this.accountCategory,
       symbol: opts.symbol,
-      start,
-      end,
+      start: start.valueOf(),
+      end: end.valueOf(),
       interval,
-      limit: 500,
+      limit,
     };
 
     const { data } = await this.xhr.get(ENDPOINTS.KLINE, { params });

--- a/src/exchanges/gate/gate.exchange.ts
+++ b/src/exchanges/gate/gate.exchange.ts
@@ -1,5 +1,7 @@
 import type { Axios } from 'axios';
 import axiosRateLimit from 'axios-rate-limit';
+import type { ManipulateType } from 'dayjs';
+import dayjs from 'dayjs';
 import chunk from 'lodash/chunk';
 import flatten from 'lodash/flatten';
 import partition from 'lodash/partition';
@@ -338,6 +340,15 @@ export class GateExchange extends BaseExchange {
   };
 
   fetchOHLCV = async (opts: OHLCVOptions) => {
+    const limit = Math.min(opts.limit || 500, 2000);
+    const [, amount, unit] = opts.interval.split(/(\d+)/);
+
+    const end = opts.to ? dayjs(opts.to) : dayjs();
+    const start =
+      !opts.limit && opts.from
+        ? dayjs(opts.from)
+        : end.subtract(parseFloat(amount) * limit, unit as ManipulateType);
+
     const market = this.store.markets.find((m) => m.symbol === opts.symbol);
 
     if (!market) {
@@ -349,7 +360,9 @@ export class GateExchange extends BaseExchange {
       params: {
         contract: market.id,
         interval: opts.interval,
-        limit: 500,
+        limit,
+        to: end.valueOf(),
+        from: start.valueOf(),
       },
     });
 

--- a/src/exchanges/woo/woo.exchange.ts
+++ b/src/exchanges/woo/woo.exchange.ts
@@ -340,7 +340,7 @@ export class WOOXExchange extends BaseExchange {
         params: {
           symbol: reverseSymbol(opts.symbol),
           type: opts.interval,
-          limit: 500,
+          limit: Math.min(opts.limit || 500, 1000),
         },
       }
     );

--- a/src/types.ts
+++ b/src/types.ts
@@ -177,6 +177,9 @@ export type UpdateOrderOpts = {
 export type OHLCVOptions = {
   readonly symbol: string;
   readonly interval: Timeframe;
+  readonly from?: number;
+  readonly to?: number;
+  readonly limit?: number;
 };
 
 export type OrderFillEvent = Pick<


### PR DESCRIPTION
This change enables usage of TradingView Charing & Trading Terminal library with `safe-cex`.

https://www.tradingview.com/charting-library-docs/latest/connecting_data/Datafeed-API/#getbars

Per documentation getBars expects data returned based on 3 parameters - from, to and countBack (or simply limit from the end) which this patch implements.

Return data to [getBars](https://www.tradingview.com/charting-library-docs/latest/api/interfaces/Charting_Library.IDatafeedChartApi#getbars) based on the following [PeriodParams](https://www.tradingview.com/charting-library-docs/latest/api/interfaces/Charting_Library.PeriodParams) properties:

[from](https://www.tradingview.com/charting-library-docs/latest/api/interfaces/Charting_Library.PeriodParams#from) — Unix timestamp of the leftmost requested bar. The library requires data in the [from, to) time range.
[to](https://www.tradingview.com/charting-library-docs/latest/api/interfaces/Charting_Library.PeriodParams#to) — Unix timestamp of the rightmost requested bar (not inclusive).
[countBack](https://www.tradingview.com/charting-library-docs/latest/api/interfaces/Charting_Library.PeriodParams#countback) — the required amount of bars to load.